### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: php
+php:
+  - 5.5
+before_script: composer install
+script: phpunit test/test_toopher_api.php


### PR DESCRIPTION
Adding a basic Travis CI configuration for PHP. Travis comes with Composer and PHPUnit installed, so we shouldn't need to do anything special.

For more, see [Travis CI Getting Started Guide](http://about.travis-ci.org/docs/user/getting-started/) and [PHP docs](http://about.travis-ci.org/docs/user/languages/php/).
