### PR TITLE
Change default param syntax to php 5.3

### DIFF
--- a/lib/toopher_api.php
+++ b/lib/toopher_api.php
@@ -118,7 +118,7 @@ class ToopherAPI
         return $this->request('GET', $endpoint);
     }
 
-    private function request($method, $endpoint, $parameters = [])
+    private function request($method, $endpoint, $parameters = array())
     {
         $req = new HTTP_Request2();
         $req->setAdapter($this->httpAdapter);


### PR DESCRIPTION
The `[]` array syntax isn't supported pre php 5.4 - switching to `array()` allows support for older installs
