### PR TITLE
Fix testing on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: php
 php:
   - 5.5
 before_script: composer install
-script: phpunit test/test_toopher_api.php
+script: vendor/bin/phpunit test/test_toopher_api.php


### PR DESCRIPTION
The library is failing to test on Travis CI: https://travis-ci.org/toopher/toopher-php

This PR aims to fix the test command so we're green again.
